### PR TITLE
Closing from a right click menu on tray

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -37,12 +37,21 @@ MainWindow::MainWindow(QWidget *parent) :
     // Only show minimize button
     //setWindowFlags(Qt::WindowTitleHint | Qt::WindowMinMaxButtonsHint);
 
-    // Tray
+    // Tray icon menu initialization
+    QAction *closeAction = new QAction("&Close", this);
+    QMenu *menu = new QMenu(this);
+    menu->addAction(closeAction);
+
+    // Tray icon initialization
     QSystemTrayIcon *tray = new QSystemTrayIcon();
     connect(tray, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(displayWindow()));
     tray->setIcon(QIcon(":/trayIcon.png"));
     tray->setToolTip("PodcastFeed");
+    tray->setContextMenu(menu);
     tray->show();
+
+    // Tray Icon Action Connects
+    connect(closeAction, SIGNAL(triggered()), this, SLOT(closeWindow()));
 
 
     //Set Media Icons
@@ -52,31 +61,39 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->skip_forward->setIcon(style()->standardIcon(QStyle::SP_MediaSkipForward));
     ui->skip_backward->setIcon(style()->standardIcon(QStyle::SP_MediaSkipBackward));
 
-    //Ser Media Connects
+    //Set Media Connects
     connect(player, SIGNAL(positionChanged(qint64)), this, SLOT(updatePosition(qint64)));
     connect(player, SIGNAL(durationChanged(qint64)), this, SLOT(setSliderRange(qint64)));
     connect(ui->playerSlider, SIGNAL(valueChanged(int)), this, SLOT(setPosition(int)));
 
 }
 
+MainWindow::~MainWindow()
+{
+    delete ui;
+}
+
 void MainWindow::closeEvent (QCloseEvent *event)
 {
-    if(this->isMinimized()){
+    if(this->isMinimized() || canClose == true){
         event->accept();
     }else{
         event->ignore();
+        canClose = true;
         this->hide();
     }
 }
 
 void MainWindow::displayWindow()
 {
+    canClose = false;
     this->show();
 }
 
-MainWindow::~MainWindow()
+void MainWindow::closeWindow()
 {
-    delete ui;
+    canClose = true;
+    this->close();
 }
 
 void MainWindow::on_actionUsing_Itunes_Link_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -22,6 +22,8 @@
 
 #include <QCloseEvent>
 #include <QSystemTrayIcon>
+#include <QMenu>
+#include <QAction>
 
 namespace Ui {
 class MainWindow;
@@ -89,6 +91,8 @@ private slots:
 
     void displayWindow();
 
+    void closeWindow();
+
 private:
     Ui::MainWindow *ui;
 
@@ -105,6 +109,8 @@ private:
     QMediaPlayer *player = new QMediaPlayer(this, QMediaPlayer::StreamPlayback);
 
     QUrl episodeFile();
+
+    bool canClose = false;
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -213,7 +213,7 @@
      <x>0</x>
      <y>0</y>
      <width>942</width>
-     <height>20</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">


### PR DESCRIPTION
Fully implemented ability to close program using a right click menu on the tray icon. If the user just attempts to close using any other close event (ex. the "X" button created by the window manager) then the program will just run `this->hide()` to hide the window.

Note that the only exception to this is when the program is already minimized and the user chooses to right click on the taskbar and click close (or any other method that triggers the close event while the window is minimized) in which case the program will actually close.