### PR TITLE
PodcastFeed_ShowPlayedEpisodes

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -689,31 +689,6 @@ void MainWindow::on_playPodcast_clicked()
 
 }
 
-/*
-void MainWindow::startupPlayPodcast(QUrl streamURL)
-{
-    // Get the values selected by the user, this should work regardless of if the widget is model or item based
-    QModelIndexList list = ui->EpisodeList->selectionModel()->selectedIndexes();
-    //set message color to red
-    ui->statusBar->setStyleSheet("color: red");
-    // User selected an episode AND the player is not currently playing any audio
-    if(list.length() > 0 && player->state() == QMediaPlayer::StoppedState){
-        ui->statusBar->showMessage("Buffering Previous Content, Please Wait...");
-        bufferPlayEpisode(streamURL);
-        player->pause();
-        ui->statusBar->showMessage("Done Buffering!", 3000);
-        ui->pauseResumeAudio->setText("Resume");
-        ui->pauseResumeAudio->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
-    }else if (list.length() > 0){
-        player->stop();
-        ui->statusBar->showMessage("Buffering Previous Content, Please Wait...");
-        bufferPlayEpisode(streamURL);
-        ui->statusBar->showMessage("Done Buffering!", 3000);
-    }
-    //reset color to default
-    ui->statusBar->setStyleSheet(styleSheet());
-*/
-
 void MainWindow::bufferPlayEpisode(QUrl streamURL){
     //Create a event loop to keep everythin inline, rather than using other functions.
     QEventLoop eventLoop;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -34,8 +34,6 @@ MainWindow::MainWindow(QWidget *parent) :
     player->setVolume(ui->volumeSlider->value());
     connect(ui->volumeSlider, SIGNAL(valueChanged(int)), player, SLOT(setVolume(int)));
 
-    LoadSettings();
-
     // Only show minimize button
     //setWindowFlags(Qt::WindowTitleHint | Qt::WindowMinMaxButtonsHint);
 
@@ -62,6 +60,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->stopAudio->setIcon(style()->standardIcon(QStyle::SP_MediaStop));
     ui->skip_forward->setIcon(style()->standardIcon(QStyle::SP_MediaSkipForward));
     ui->skip_backward->setIcon(style()->standardIcon(QStyle::SP_MediaSkipBackward));
+
+    LoadSettings();
 
     //Set Media Connects
     connect(player, SIGNAL(positionChanged(qint64)), this, SLOT(updatePosition(qint64)));
@@ -640,7 +640,7 @@ bool MainWindow::checkPodcastExists(QString podcastName){
     return false;
 }
 
-void MainWindow::on_playPodcast_clicked()
+void MainWindow::on_playPodcast_clicked(bool blReload)
 {
     QSettings setting("3PR3", "PodcastFeed");
     setting.beginGroup("MainWindow_BufferPlay");
@@ -657,11 +657,12 @@ void MainWindow::on_playPodcast_clicked()
     if(list.length() > 0 && player->state() == QMediaPlayer::StoppedState){
         ui->statusBar->showMessage("Buffering Content, Please Wait...");
         //If playPodcast is called with a QURL, load the QUrl instead.
-        if(streamURL.isEmpty()){
-            bufferPlayEpisode(episodeFile());
+        if(blReload){
+            bufferPlayEpisode(streamURL);
+            on_pauseResumeAudio_clicked();
         }
         else{
-            bufferPlayEpisode(streamURL);
+            bufferPlayEpisode(episodeFile());
         }
 
         ui->statusBar->showMessage("Done Buffering!", 3000);
@@ -675,13 +676,13 @@ void MainWindow::on_playPodcast_clicked()
         player->stop();
         ui->statusBar->showMessage("Buffering Content, Please Wait...");
 
-        if(streamURL.isEmpty()){
-            bufferPlayEpisode(episodeFile());
+        if(blReload){
+            bufferPlayEpisode(streamURL);
+            on_pauseResumeAudio_clicked();
         }
         else{
-            bufferPlayEpisode(streamURL);
+            bufferPlayEpisode(episodeFile());
         }
-
         ui->statusBar->showMessage("Done Buffering!", 3000);
     }
     //reset color to default
@@ -877,7 +878,7 @@ void MainWindow::LoadSettings(){
                 //ui->EpisodeList->setCurrentRow(setting.value("EpisodeRow").toInt())
         setting.endGroup();
 
-        on_playPodcast_clicked();
+        on_playPodcast_clicked(true);
 
 
         setting.beginGroup("MainWindow");

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -267,9 +267,11 @@ void MainWindow::on_PodcastList_clicked(const QModelIndex &index)
 
     //Trying to figure out why the Ascend / Descend feature no longer works after I added PreviousPlayed feature.
     ui->EpisodeList->clear();
+
         setting.beginGroup("MainWindow");
             if(setting.value("SortOrderAscend") == false){
                 std::reverse(Episodes.begin(), Episodes.end());
+                std::reverse(ListenedEpisodes.begin(), ListenedEpisodes.end());
             }
         setting.endGroup();
 
@@ -912,15 +914,15 @@ void MainWindow::SaveSettings(){
     //Settings are also set in other function when applicable.
     setting.beginGroup("MainWindow");
         //Sets the bool settings for if AscendingSortOrder is enabled or disabled
-        if(ui->actionSorting_Order_Ascending->isEnabled() == true){
+        if(ui->actionSort_Order_Ascending->isEnabled() == true){
             setting.setValue("SortOrderAscend", false);
         }
-        else if(ui->actionSorting_Order_Ascending->isEnabled() == false){
+        else if(ui->actionSort_Order_Ascending->isEnabled() == false){
             setting.setValue("SortOrderAscend", true);
         }
         else{
             //This is the default if there is no setting.
-            setting.setValue("SortOrderAscend", false);
+            setting.setValue("SortOrderAscend", true);
         }
 
         //Sets the bool setting for if Buffering is enabled or disabled
@@ -969,18 +971,22 @@ void MainWindow::LoadSettings(){
                 //SortOrderAscend = fasle means Sort Order is set to Descending
                 if(setting.value("SortOrderAscend").toBool() == true){
                     //If the sort order is currently true for Ascending then you don't need set Ascending anymore.
-                    ui->actionSorting_Order_Ascending->setEnabled(false);
+                    ui->actionSort_Order_Ascending->setEnabled(false);
                     //If the sort order is currently true for Ascending then it means the option of Descending should be available.
-                    ui->actionSorting_Order_Descending->setEnabled(true);
+                    ui->actionSort_Order_Descending->setEnabled(true);
                 }
                 else if(setting.value("SortOrderAscend").toBool() == false){
                     //If the sort order is currently false for Ascending then it means the option of Ascending should be available.
-                    ui->actionSorting_Order_Ascending->setEnabled(true);
+                    ui->actionSort_Order_Ascending->setEnabled(true);
                     //If the sort order is currentl false for Ascending then it means the options of Descending should not be available.
-                    ui->actionSorting_Order_Descending->setEnabled(false);
+                    ui->actionSort_Order_Descending->setEnabled(false);
                 }
                 else{
-                    //Do Nothing.
+                    //If the sort order is currently false for Ascending then it means the option of Ascending should be available.
+                    ui->actionSort_Order_Ascending->setEnabled(true);
+                    //If the sort order is currently false for Ascending then it means the option of Descending should not be available.
+                    ui->actionSort_Order_Descending->setEnabled(false);
+                    setting.setValue("SortOrderAscend", false);
                 }
 
                 //Sets the bool setting for if Buffering is enabled or disabled
@@ -1008,7 +1014,7 @@ void MainWindow::on_actionEnable_Buffering_triggered()
         setting.setValue("BufferingEnabled", ui->actionEnable_Buffering->isChecked());
     setting.endGroup();
 }
-
+/*
 void MainWindow::on_actionSorting_Order_Descending_triggered()
 {
         setting.beginGroup("MainWindow");
@@ -1028,5 +1034,28 @@ void MainWindow::on_actionSorting_Order_Ascending_triggered()
         ui->actionSorting_Order_Ascending->setEnabled(false);
         setting.endGroup();
 }
+*/
 
+void MainWindow::on_actionSort_Order_Ascending_triggered()
+{
+    setting.beginGroup("MainWindow");
+    setting.setValue("SortOrderAscend", true);
+    ui->actionSort_Order_Descending->setEnabled(true);
+    ui->actionSort_Order_Ascending->setEnabled(false);
+    setting.endGroup();
 
+    //Populate the widgets
+    updateUIPodcastList();
+}
+
+void MainWindow::on_actionSort_Order_Descending_triggered()
+{
+    setting.beginGroup("MainWindow");
+    setting.setValue("SortOrderAscend", false);
+    ui->actionSort_Order_Descending->setEnabled(false);
+    ui->actionSort_Order_Ascending->setEnabled(true);
+    setting.endGroup();
+
+    //Populate the widgets
+    updateUIPodcastList();
+}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1014,27 +1014,6 @@ void MainWindow::on_actionEnable_Buffering_triggered()
         setting.setValue("BufferingEnabled", ui->actionEnable_Buffering->isChecked());
     setting.endGroup();
 }
-/*
-void MainWindow::on_actionSorting_Order_Descending_triggered()
-{
-        setting.beginGroup("MainWindow");
-        setting.value("SortOrderAscend", false);
-        ui->actionSorting_Order_Descending->setEnabled(false);
-        ui->actionSorting_Order_Ascending->setEnabled(true);
-        setting.endGroup();
-}
-
-
-
-void MainWindow::on_actionSorting_Order_Ascending_triggered()
-{
-        setting.beginGroup("MainWindow");
-        setting.value("SortOrderAscend", true);
-        ui->actionSorting_Order_Descending->setEnabled(true);
-        ui->actionSorting_Order_Ascending->setEnabled(false);
-        setting.endGroup();
-}
-*/
 
 void MainWindow::on_actionSort_Order_Ascending_triggered()
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -34,6 +34,8 @@ MainWindow::MainWindow(QWidget *parent) :
     player->setVolume(ui->volumeSlider->value());
     connect(ui->volumeSlider, SIGNAL(valueChanged(int)), player, SLOT(setVolume(int)));
 
+    LoadSettings();
+
     // Only show minimize button
     //setWindowFlags(Qt::WindowTitleHint | Qt::WindowMinMaxButtonsHint);
 
@@ -65,8 +67,8 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(player, SIGNAL(positionChanged(qint64)), this, SLOT(updatePosition(qint64)));
     connect(player, SIGNAL(durationChanged(qint64)), this, SLOT(setSliderRange(qint64)));
     connect(ui->playerSlider, SIGNAL(valueChanged(int)), this, SLOT(setPosition(int)));
-
 }
+
 
 MainWindow::~MainWindow()
 {
@@ -92,10 +94,19 @@ void MainWindow::displayWindow()
 
 void MainWindow::closeWindow()
 {
+    SaveSettings();
+
+    /*
+    QSettings setting("3PR3", "PodcastFeed");
+
+    setting.beginGroup("MainWindow");
+            setting.setValue("MediaPosition", player->position());
+    setting.endGroup();
+    */
     canClose = true;
+
     this->close();
 }
-
 void MainWindow::on_actionUsing_Itunes_Link_triggered()
 {
     //Bool to tell if user clicked ok on dialog.
@@ -196,6 +207,7 @@ void MainWindow::on_actionRemove_Podcast_triggered()
 void MainWindow::on_PodcastList_clicked(const QModelIndex &index)
 {
     QString podcastName = ui->PodcastList->item(index.row())->text();
+
     QString podcastDescription;
     QStringList Episodes;
 
@@ -251,10 +263,12 @@ void MainWindow::on_PodcastList_clicked(const QModelIndex &index)
     ui->Description->setText(podcastDescription);
 }
 
+
 void MainWindow::on_EpisodeList_clicked(const QModelIndex &index)
 {
     QString podcastName = ui->PodcastList->currentItem()->text();
     QString episodeName = ui->EpisodeList->item(index.row())->text();
+
     QString episodeDescription;
 
     QString podcastFilePath = xmlFolder + "/" + podcastName + ".xml";
@@ -628,6 +642,12 @@ bool MainWindow::checkPodcastExists(QString podcastName){
 
 void MainWindow::on_playPodcast_clicked()
 {
+    QSettings setting("3PR3", "PodcastFeed");
+    setting.beginGroup("MainWindow_BufferPlay");
+        //Loads and formats the QURL for the previous stream.
+        QUrl streamURL = setting.value("curQUrl").toUrl();
+    setting.endGroup();
+
     // Get the values selected by the user, this should work regardless of if the widget is model or item based
     QModelIndexList list = ui->EpisodeList->selectionModel()->selectedIndexes();
     //set message color to red
@@ -636,12 +656,32 @@ void MainWindow::on_playPodcast_clicked()
     // User selected an episode AND the player is not currently playing any audio
     if(list.length() > 0 && player->state() == QMediaPlayer::StoppedState){
         ui->statusBar->showMessage("Buffering Content, Please Wait...");
-        bufferPlayEpisode();
+        //If playPodcast is called with a QURL, load the QUrl instead.
+        if(streamURL.isEmpty()){
+            bufferPlayEpisode(episodeFile());
+        }
+        else{
+            bufferPlayEpisode(streamURL);
+        }
+
         ui->statusBar->showMessage("Done Buffering!", 3000);
     }else if (list.length() > 0){
+
+        //Record the MediaPosition in QSettings:
+        setting.beginGroup("MainWindow");
+                setting.setValue("MediaPosition", player->position());
+        setting.endGroup();
+
         player->stop();
         ui->statusBar->showMessage("Buffering Content, Please Wait...");
-        bufferPlayEpisode();
+
+        if(streamURL.isEmpty()){
+            bufferPlayEpisode(episodeFile());
+        }
+        else{
+            bufferPlayEpisode(streamURL);
+        }
+
         ui->statusBar->showMessage("Done Buffering!", 3000);
     }
     //reset color to default
@@ -649,7 +689,32 @@ void MainWindow::on_playPodcast_clicked()
 
 }
 
-void MainWindow::bufferPlayEpisode(){
+/*
+void MainWindow::startupPlayPodcast(QUrl streamURL)
+{
+    // Get the values selected by the user, this should work regardless of if the widget is model or item based
+    QModelIndexList list = ui->EpisodeList->selectionModel()->selectedIndexes();
+    //set message color to red
+    ui->statusBar->setStyleSheet("color: red");
+    // User selected an episode AND the player is not currently playing any audio
+    if(list.length() > 0 && player->state() == QMediaPlayer::StoppedState){
+        ui->statusBar->showMessage("Buffering Previous Content, Please Wait...");
+        bufferPlayEpisode(streamURL);
+        player->pause();
+        ui->statusBar->showMessage("Done Buffering!", 3000);
+        ui->pauseResumeAudio->setText("Resume");
+        ui->pauseResumeAudio->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
+    }else if (list.length() > 0){
+        player->stop();
+        ui->statusBar->showMessage("Buffering Previous Content, Please Wait...");
+        bufferPlayEpisode(streamURL);
+        ui->statusBar->showMessage("Done Buffering!", 3000);
+    }
+    //reset color to default
+    ui->statusBar->setStyleSheet(styleSheet());
+*/
+
+void MainWindow::bufferPlayEpisode(QUrl streamURL){
     //Create a event loop to keep everythin inline, rather than using other functions.
     QEventLoop eventLoop;
     //create new network manager
@@ -658,7 +723,7 @@ void MainWindow::bufferPlayEpisode(){
     QObject::connect(manager, SIGNAL(finished(QNetworkReply*)), &eventLoop, SLOT(quit()));
 
     QNetworkRequest request;
-    request.setUrl(episodeFile());
+    request.setUrl(streamURL);
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
 
     QNetworkReply *audioReply = manager->get(request);
@@ -672,12 +737,29 @@ void MainWindow::bufferPlayEpisode(){
     immPlay.open(QIODevice::ReadOnly);
     player->setMedia(QMediaContent(), &immPlay);
     player->play();
+
+    //Set Setting Values for current rows of Podcast and Episode.
+    //Also set the current QURL for the stream.
+    QSettings setting("3PR3", "PodcastFeed");
+    setting.beginGroup("MainWindow_BufferPlay");
+        setting.setValue("PodcastRow", ui->PodcastList->currentRow());
+        setting.setValue("EpisodeRow", ui->EpisodeList->currentRow());
+        setting.setValue("curQUrl", streamURL.toString());
+    setting.endGroup();
+
 }
 
 void MainWindow::on_stopAudio_clicked()
 {
+    //Set the MediaPosition setting during the stopping of Audio.
+    QSettings setting("3PR3", "PodcastFeed");
+    setting.beginGroup("MainWindow");
+            setting.setValue("MediaPosition", player->position());
+    setting.endGroup();
+
     player->stop();
 }
+
 
 void MainWindow::on_pauseResumeAudio_clicked()
 {
@@ -773,3 +855,71 @@ QUrl MainWindow::episodeFile()
     return audioFile;
 }
 //end Author:Vamsidhar Allampati
+
+void MainWindow::SaveSettings(){
+    //Function used for default saving of settings.
+    //Settings are also set in other function when applicable.
+
+    QSettings setting("3PR3", "PodcastFeed");
+    setting.beginGroup("MainWindow");
+        //Sets the value for the window size
+        setting.setValue("position", this->geometry());
+        //Sets the volume settings for later
+        setting.setValue("volume", player->volume());
+        //Sets the Media Position of the last playing file.
+        setting.setValue("MediaPosition", player->position());
+    setting.endGroup();
+
+    qDebug() << "Settings Saved";
+}
+
+void MainWindow::LoadSettings(){
+    //Load
+    QSettings setting("3PR3", "PodcastFeed");
+
+        setting.beginGroup("MainWindow");
+                //Reloads the position or dimensions of the MainWindow.
+                QRect MainRect = setting.value("position").toRect();
+                setGeometry(MainRect);
+                //Loads in the volume last saved in settings and graphically.
+                int intVolume = setting.value("volume").toInt();
+                ui->volumeSlider->setValue(intVolume);
+
+                //Still working with this section. Going to change it to Singal and Slot design.
+                //Trying to get the loaded QUrl to show relevant podcast and episode info
+                //in the ui.
+                int podcastRow = setting.value("PodcastRow").toInt();
+                QListWidgetItem* itemPodcast = ui->PodcastList->item(podcastRow);
+                ui->PodcastList->setCurrentItem(itemPodcast);
+                const QModelIndex PodcastIndex = ui->PodcastList->currentIndex();
+                on_PodcastList_clicked(PodcastIndex);
+
+                int episodeRow = setting.value("EpisodeRow").toInt();
+                QListWidgetItem* itemEpisode = ui->EpisodeList->item(episodeRow);
+                ui->EpisodeList->setCurrentItem(itemEpisode);
+                const QModelIndex EpisodeIndex = ui->EpisodeList->currentIndex();
+                on_EpisodeList_clicked(EpisodeIndex);
+                //ui->EpisodeList->setCurrentRow(setting.value("EpisodeRow").toInt())
+        setting.endGroup();
+
+        on_playPodcast_clicked();
+
+
+        setting.beginGroup("MainWindow");
+                //Set the media position after loading the correct Url Stream.
+                qint64 MediaPosition = setting.value("MediaPosition").toLongLong();
+                setPosition(MediaPosition);
+        setting.endGroup();
+}
+
+void MainWindow::on_actionSave_Settings_triggered()
+{
+    //Save
+    SaveSettings();
+}
+
+void MainWindow::on_actionLoad_Settings_triggered()
+{
+    //Load
+    LoadSettings();
+}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -106,6 +106,7 @@ private slots:
 
     void on_actionLoad_Settings_triggered();
 
+    void on_actionEnable_Buffering_triggered();
 
 private:
     Ui::MainWindow *ui;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -114,9 +114,13 @@ private slots:
 
     void on_actionEnable_Buffering_triggered();
 
-    void on_actionSorting_Order_Descending_triggered();
+   // void on_actionSorting_Order_Descending_triggered();
 
-    void on_actionSorting_Order_Ascending_triggered();
+   // void on_actionSorting_Order_Ascending_triggered();
+
+    void on_actionSort_Order_Ascending_triggered();
+
+    void on_actionSort_Order_Descending_triggered();
 
 private:
     Ui::MainWindow *ui;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -28,6 +28,8 @@
 
 #include <QSettings>
 
+#include <QFileInfo>
+
 namespace Ui {
 class MainWindow;
 }
@@ -54,6 +56,8 @@ private slots:
 
     void on_EpisodeList_clicked(const QModelIndex &index);
 
+    bool FileExists(QString filechkPath);
+
     void updateUIPodcastList();
 
     QString addPodcast_dlg(QString Label, QString Title, bool &ok);
@@ -65,6 +69,8 @@ private slots:
     void addPodcast(QString rssLink, bool actionType);
 
     void storeXmlFile(QString podcastName, QByteArray rawReply);
+
+    void CreateEpisodeTextFile(QString podcastName, QString episodeName);
 
     void storeIcon(QString podcastName, QString iconURL);
 
@@ -88,7 +94,7 @@ private slots:
 
     void on_skip_forward_clicked();
 
-    void on_playPodcast_clicked(bool blReload);
+    void on_playPodcast_clicked();
 
     void setPosition(int position);
 
@@ -108,12 +114,18 @@ private slots:
 
     void on_actionEnable_Buffering_triggered();
 
+    void on_actionSorting_Order_Descending_triggered();
+
+    void on_actionSorting_Order_Ascending_triggered();
+
 private:
     Ui::MainWindow *ui;
 
     QNetworkAccessManager *manager;
 
     QString appDataFolder = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/PodcastFeed";
+
+    QString txtListened = appDataFolder + "/listened";
 
     QString xmlFolder = appDataFolder + "/xml";
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -26,6 +26,8 @@
 #include <QMenu>
 #include <QAction>
 
+#include <QSettings>
+
 namespace Ui {
 class MainWindow;
 }
@@ -94,7 +96,16 @@ private slots:
 
     void closeWindow();
 
-    void bufferPlayEpisode();
+    void bufferPlayEpisode(QUrl streamURL);
+
+    void SaveSettings();
+
+    void LoadSettings();
+
+    void on_actionSave_Settings_triggered();
+
+    void on_actionLoad_Settings_triggered();
+
 
 private:
     Ui::MainWindow *ui;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -88,7 +88,7 @@ private slots:
 
     void on_skip_forward_clicked();
 
-    void on_playPodcast_clicked();
+    void on_playPodcast_clicked(bool blReload);
 
     void setPosition(int position);
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -235,10 +235,21 @@
      <addaction name="actionLoad_Settings"/>
      <addaction name="actionEnable_Buffering"/>
     </widget>
+    <widget class="QMenu" name="menuSorting_Order_2">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="title">
+      <string>Sorting Order</string>
+     </property>
+     <addaction name="actionSorting_Order_Ascending"/>
+     <addaction name="actionSorting_Order_Descending"/>
+    </widget>
     <addaction name="menuAdd_Podcast"/>
     <addaction name="actionRefresh_Feed"/>
     <addaction name="actionRemove_Podcast"/>
     <addaction name="menuSettings"/>
+    <addaction name="menuSorting_Order_2"/>
    </widget>
    <widget class="QMenu" name="menuFile">
     <property name="title">
@@ -294,6 +305,25 @@
    </property>
    <property name="text">
     <string>Enable Buffering</string>
+   </property>
+  </action>
+  <action name="actionSorting_Order_Ascending">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Sorting Order Ascending</string>
+   </property>
+  </action>
+  <action name="actionSorting_Order_Descending">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Sorting Order Descending</string>
    </property>
   </action>
  </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -235,21 +235,21 @@
      <addaction name="actionLoad_Settings"/>
      <addaction name="actionEnable_Buffering"/>
     </widget>
-    <widget class="QMenu" name="menuSorting_Order_2">
+    <widget class="QMenu" name="menuSortingOrder">
      <property name="enabled">
       <bool>true</bool>
      </property>
      <property name="title">
       <string>Sorting Order</string>
      </property>
-     <addaction name="actionSorting_Order_Ascending"/>
-     <addaction name="actionSorting_Order_Descending"/>
+     <addaction name="actionSort_Order_Ascending"/>
+     <addaction name="actionSort_Order_Descending"/>
     </widget>
     <addaction name="menuAdd_Podcast"/>
     <addaction name="actionRefresh_Feed"/>
     <addaction name="actionRemove_Podcast"/>
     <addaction name="menuSettings"/>
-    <addaction name="menuSorting_Order_2"/>
+    <addaction name="menuSortingOrder"/>
    </widget>
    <widget class="QMenu" name="menuFile">
     <property name="title">
@@ -307,23 +307,20 @@
     <string>Enable Buffering</string>
    </property>
   </action>
-  <action name="actionSorting_Order_Ascending">
-   <property name="checkable">
-    <bool>false</bool>
-   </property>
+  <action name="actionSort_Order_Ascending">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Sorting Order Ascending</string>
+    <string>Sort Order Ascending</string>
    </property>
   </action>
-  <action name="actionSorting_Order_Descending">
+  <action name="actionSort_Order_Descending">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Sorting Order Descending</string>
+    <string>Sort Order Descending</string>
    </property>
   </action>
  </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -227,11 +227,18 @@
      <addaction name="actionUsing_Itunes_Link"/>
      <addaction name="actionUsing_RSS_Link"/>
     </widget>
+    <widget class="QMenu" name="menuSettings">
+     <property name="title">
+      <string>Settings</string>
+     </property>
+     <addaction name="actionSave_Settings"/>
+     <addaction name="actionLoad_Settings"/>
+     <addaction name="actionEnable_Buffering"/>
+    </widget>
     <addaction name="menuAdd_Podcast"/>
     <addaction name="actionRefresh_Feed"/>
     <addaction name="actionRemove_Podcast"/>
-    <addaction name="actionSave_Settings"/>
-    <addaction name="actionLoad_Settings"/>
+    <addaction name="menuSettings"/>
    </widget>
    <widget class="QMenu" name="menuFile">
     <property name="title">
@@ -276,6 +283,17 @@
   <action name="actionExit">
    <property name="text">
     <string>Exit</string>
+   </property>
+  </action>
+  <action name="actionEnable_Buffering">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Enable Buffering</string>
    </property>
   </action>
  </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>942</width>
-    <height>517</height>
+    <height>539</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -213,7 +213,7 @@
      <x>0</x>
      <y>0</y>
      <width>942</width>
-     <height>21</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">
@@ -230,7 +230,16 @@
     <addaction name="menuAdd_Podcast"/>
     <addaction name="actionRefresh_Feed"/>
     <addaction name="actionRemove_Podcast"/>
+    <addaction name="actionSave_Settings"/>
+    <addaction name="actionLoad_Settings"/>
    </widget>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionExit"/>
+   </widget>
+   <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
@@ -252,6 +261,21 @@
   <action name="actionRemove_Podcast">
    <property name="text">
     <string>Remove Podcast</string>
+   </property>
+  </action>
+  <action name="actionSave_Settings">
+   <property name="text">
+    <string>Save_Settings</string>
+   </property>
+  </action>
+  <action name="actionLoad_Settings">
+   <property name="text">
+    <string>Load_Settings</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Things that were added:

-Added functionality for storing played episodes under the folder /listened/<relevant podcast>/<episode name>.txt with CreateEpisodeTextFile(podcastName, episodeName);
Each episode has its own file.
We can also use these files for storing other relevant information for played files when playing.

-Added functionality to check for existence of a file with "QFileInfo" and bool FileExists(filechkPath)

-Added functionality for changing color of played podcasts to grey.

Things that were removed:
-Removed the volume settings.
-Removed the last position and QUrl Settings.

-Toggle for Buffering/Non-Buffering still works.

Bugs:
-It seems that Ascending/Descending has stopped working. May be because I made some UI changes, might also be because of the change to showing played podcasts.


